### PR TITLE
Fix missing status code in Apps Script JSON responses

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -100,7 +100,8 @@ function validate_(data) {
  */
 function jsonResponse_(obj, statusCode) {
   const output = ContentService.createTextOutput(JSON.stringify(obj))
-    .setMimeType(ContentService.MimeType.JSON);
+    .setMimeType(ContentService.MimeType.JSON)
+    .setStatusCode(statusCode || 200);
   return output;
 }
 


### PR DESCRIPTION
## Summary
- ensure `jsonResponse_` sets an HTTP status code

## Testing
- `node --check app.js`
- `node --check --input-type=module < Code.gs`


------
https://chatgpt.com/codex/tasks/task_e_68a1e53beb108323af0a939576954697